### PR TITLE
Workflow permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["ma*"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MaanasArora/convergent/security/code-scanning/3](https://github.com/MaanasArora/convergent/security/code-scanning/3)

The problem can be fixed by adding a `permissions` block to the root of the workflow. This ensures that the workflow explicitly defines the required minimum permissions for its tasks. Based on the actions performed in the workflow, the least privilege required appears to be `contents: read`. This allows the workflow to read repository contents, which is necessary for tasks like checking out code. No `write` permissions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
