### PR TITLE
fix: prevent empty comments from being submitted and show hover message

### DIFF
--- a/client/src/components/admin/comments/CommentConfig.tsx
+++ b/client/src/components/admin/comments/CommentConfig.tsx
@@ -14,6 +14,8 @@ export default function CommentConfig({
   onCancel?: () => void;
 }) {
   const [comment, setComment] = useState("");
+  const [isHovering, setIsHovering] = useState(false);
+  
   async function formSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     // const formData = new FormData(event.target as HTMLFormElement);
@@ -66,17 +68,33 @@ export default function CommentConfig({
       <div className="flex gap-2 my-4 flex-wrap">
         <button
           type="button"
-          className="p-2 border-2 rounded-md hover:bg-red-800 hover:border-red-800 hover:text-white grow-1"
+          className="p-2 border-2 rounded-md hover:bg-red-800 hover:border-red-800 hover:text-white flex-1"
           onClick={onFormCancel}
         >
           Cancel
         </button>
-        <button
-          type="submit"
-          className="p-2 bg-gray-500 hover:bg-secondary text-white rounded-md grow-1"
+        <div
+          className="relative flex-1"
+          onMouseEnter={() => setIsHovering(true)}
+          onMouseLeave={() => setIsHovering(false)}
         >
-          Add Comment
-        </button>
+          <button
+            type="submit"
+            className={`p-2 bg-gray-500 text-white rounded-md w-full ${comment.trim() === "" ? "cursor-default" : "bg-secondary"}`}
+            disabled={comment.trim() === ""} 
+          >
+            Add Comment
+          </button>
+        </div>
+        {comment.trim() === "" && isHovering && (
+          <div 
+            className="absolute -bottom-12 left-1/2 -translate-x-1/2 bg-white border border-gray-300 rounded-md shadow px-3 py-1 text-sm text-gray-700 z-50 transition-opacity duration-300 ease-in-out"
+            role="tooltip"
+            aria-live="polite"
+          >
+            Comment is empty
+          </div>
+        )}
       </div>
     </form>
   );

--- a/client/src/components/admin/comments/CommentDialog.tsx
+++ b/client/src/components/admin/comments/CommentDialog.tsx
@@ -42,7 +42,7 @@ export function NewCommentDialog({
 
       <dialog
         id="comment-dialog"
-        className="md:m-[revert] p-[revert] md:border-2 backdrop:bg-primary backdrop:opacity-80 md:rounded-xl w-full max-w-3xl relative h-screen md:h-[revert]"
+        className="md:m-[revert] p-[revert] md:border-2 backdrop:bg-primary backdrop:opacity-80 md:rounded-xl w-full max-w-3xl relative h-screen md:h-[revert] overflow-visible"
       >
         <button
           type="button"


### PR DESCRIPTION
Fixes #123 

- disabled the submit button unless the comment is non-empty
- prevents submission of empty comments in conversations
- added `isHovering` state to track mouse hover on the submit button
- when hovering and comment is empty, a message appears explaining why the button is disabled